### PR TITLE
Fix article page 404 due to path IDs

### DIFF
--- a/webapp/utils.py
+++ b/webapp/utils.py
@@ -59,7 +59,8 @@ def parse_markdown(path: Path) -> Optional[Article]:
     date = header.get("date", "")
     html = md.markdown(body)
     summary = body.split("\n", 1)[0]
-    return Article(str(path), title, date, summary, html, str(path))
+    identifier = str(path.relative_to(REPORTS_DIR))
+    return Article(identifier, title, date, summary, html, str(path))
 
 
 def load_articles() -> List[Article]:
@@ -74,7 +75,7 @@ def load_articles() -> List[Article]:
         art = parse_markdown(md_file)
         if art is None:
             continue
-        extra = meta.get(art.id, {})
+        extra = meta.get(art.id, meta.get(str(md_file), {}))
         art.tags = extra.get("tags", [])
         art.likes = extra.get("likes", 0)
         art.dislikes = extra.get("dislikes", 0)


### PR DESCRIPTION
## Summary
- ensure IDs stored for articles use relative paths
- allow metadata lookup via old absolute paths

## Testing
- `pre-commit run -a` *(fails: flake8 missing)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_6867dccb21708325b92435a950a20144